### PR TITLE
Get catalog location as path instead of URL - Fix for auto dir on Linux

### DIFF
--- a/src/main/java/net/sf/colorer/eclipse/ColorerPlugin.java
+++ b/src/main/java/net/sf/colorer/eclipse/ColorerPlugin.java
@@ -5,6 +5,7 @@ import java.util.Enumeration;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.Vector;
+import java.io.File;
 
 import net.sf.colorer.FileType;
 import net.sf.colorer.ParserFactory;
@@ -21,7 +22,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
 import org.eclipse.ui.texteditor.ChainedPreferenceStore;
 import org.osgi.framework.BundleContext;
-
+import org.eclipse.core.runtime.FileLocator;
 
 /**
  * The main plugin class to be used in the desktop.
@@ -119,8 +120,8 @@ public class ColorerPlugin extends AbstractUIPlugin {
             return parserFactory;
         }
         try {
-            catalogPath = new URL(Platform.resolve(
-                    getBundle().getEntry("/")), "colorer/catalog.xml").toExternalForm();
+            catalogPath = new File(FileLocator.getBundleFile(getBundle()), "colorer/catalog.xml")
+                .getPath();
             Logger.trace("EclipsecolorerPlugin", "Catalog: "+catalogPath);
             parserFactory = new ParserFactory(catalogPath);
         } catch (Throwable e) {


### PR DESCRIPTION
I noticed that the Eclipse plug-in does not pick up color files from the `colorer/hrc/auto` directory on Linux (and probably on Mac, I have not had the opportunity to test that).

This pull request contains a fix for that.
##### Cause description

The problem is caused by the way file path to the `catalog.xml` file is handled in `ColorerPlugin.java` and `ParserFactory.cpp`. A URL represented by a string is passed from Java to C++ where the protocol part (ex: `file:/`) is stripped with the intention to get only the file path. On Windows this seems to work, but on Linux (and probably Mac since that's a Unix) the leading `/` of the path is also stripped, making it into a relative path where an absolute path is expected.

By a coincidence this works for the `proto.hrc` file, but not for the `auto` directory.
##### Fix

The change in this pull request fixes this by passing the path to `catalog.xml` to the parser factory as normal path, i.e. without a leading `file:/` prefix. The code in `ParserFactory.cpp` seems to handle this well on all platforms.

I have confirmed that this works for both `auto` and `proto.xml` on Windows and Linux and it really should work on Mac also.

(The fix uses `FileLocator` instead of `Platform.resolve` so it also gets rid of a deprecation warning.)
##### Long term fix suggestion

It would probably be a good idea to update `ParserFactory::getHRCParser` and fix the code that strips the `file:` prefix so that this works in a platform independent way.

I noticed that the same kind of code also is used in `FileInputSource::FileInputSource`.
